### PR TITLE
Add SQL user mode options

### DIFF
--- a/templates/users.j2
+++ b/templates/users.j2
@@ -85,6 +85,15 @@
         {% if user.access_management is defined %}
         <access_management>{{ user.access_management }}</access_management>
         {% endif %}
+        {% if user.named_collection_control is defined %}
+        <named_collection_control>{{ user.named_collection_control }}</named_collection_control>
+        {% endif %}
+        {% if user.show_named_collections is defined %}
+        <show_named_collections>{{ user.show_named_collections }}</show_named_collections>
+        {% endif %}
+        {% if user.show_named_collections_secrets is defined %}
+        <show_named_collections_secrets>{{ user.show_named_collections_secrets }}</show_named_collections_secrets>
+        {% endif %}
     </{{ user.name }}>
     {% endfor %}
     </users>


### PR DESCRIPTION
As per https://clickhouse.com/docs/en/operations/access-rights#enabling-access-control, enabling SQL user mode now requires the named_collection_control, show_named_collections, and show_named_collections_secrets parameters. Add support for these parameters to the module, in addition to access_management, which is already supported.